### PR TITLE
test: seeded-repo e2e positive for the new-pool-module advisory (F4)

### DIFF
--- a/plugins/charness/scripts/slice_closeout_advisories.py
+++ b/plugins/charness/scripts/slice_closeout_advisories.py
@@ -59,7 +59,9 @@ def advise_new_pool_module(repo_root: Path, changed_paths: list[str]) -> None:
     degrades) are uncovered; the first signal otherwise arrives at the bundle
     boundary, where repair costs a full instrumented producer re-run. Surface
     the documented early self-check (implementation-discipline.md) while the
-    branch list is still cheap to walk."""
+    branch list is still cheap to walk. The unmocked glue (real git anchor +
+    real eligibility glob) is pinned end-to-end by the seeded-repo positive in
+    tests/quality_gates/test_slice_closeout_new_pool_advisory.py."""
     changed_py = [path for path in changed_paths if path.endswith(".py")]
     if not changed_py:
         return

--- a/scripts/slice_closeout_advisories.py
+++ b/scripts/slice_closeout_advisories.py
@@ -59,7 +59,9 @@ def advise_new_pool_module(repo_root: Path, changed_paths: list[str]) -> None:
     degrades) are uncovered; the first signal otherwise arrives at the bundle
     boundary, where repair costs a full instrumented producer re-run. Surface
     the documented early self-check (implementation-discipline.md) while the
-    branch list is still cheap to walk."""
+    branch list is still cheap to walk. The unmocked glue (real git anchor +
+    real eligibility glob) is pinned end-to-end by the seeded-repo positive in
+    tests/quality_gates/test_slice_closeout_new_pool_advisory.py."""
     changed_py = [path for path in changed_paths if path.endswith(".py")]
     if not changed_py:
         return

--- a/tests/quality_gates/test_slice_closeout_new_pool_advisory.py
+++ b/tests/quality_gates/test_slice_closeout_new_pool_advisory.py
@@ -68,6 +68,34 @@ def test_advisory_silent_for_new_non_pool_python(monkeypatch: pytest.MonkeyPatch
     assert capsys.readouterr().err == ""
 
 
+def test_advisory_end_to_end_fires_in_seeded_repo(tmp_path: Path, capsys) -> None:
+    # F4 from the advisory's introduction critique: the unmocked glue — a real
+    # git anchor (the seeded local `origin/main` branch, the base-range
+    # `_seed_repo` pattern) and the real eligibility glob over the tmp repo —
+    # fires for a pool module added on HEAD but absent from the anchor.
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    git("init", "-b", "main")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test User")
+    (tmp_path / "base.txt").write_text("base\n", encoding="utf-8")
+    git("add", "base.txt")
+    git("commit", "-m", "base")
+    git("branch", "origin/main")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "fresh_pool_module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "scripts/fresh_pool_module.py")
+    git("commit", "-m", "add pool module")
+
+    advise_new_pool_module(tmp_path, ["scripts/fresh_pool_module.py", "base.txt"])
+
+    err = capsys.readouterr().err
+    assert "scripts/fresh_pool_module.py" in err
+    assert "CONFIRMS instead of discovering" in err
+    assert "implementation-discipline.md" in err
+
+
 def test_run_slice_closeout_wires_the_advisory_call_site() -> None:
     # A deleted call site would pass the function-level tests; pin both the
     # rebinding and the invocation beside the sibling advisories.


### PR DESCRIPTION
## What

Lands the deferred **F4** test from the new-pool-module advisory's introduction critique: an end-to-end seeded-tmp-repo positive for `advise_new_pool_module` exercising the unmocked glue — a real git anchor (seeded local `origin/main`, the `_seed_repo` pattern from `tests/quality_gates/test_slice_closeout_base_range.py`) and the real eligibility glob — instead of the piecewise mocked seams. The advisory's docstring notes the e2e pin (plugin mirror byte-synced).

## Why a pool-file touch is included

This PR is the `quality-core.yml` **PR-mirror job's first execution on a real pull request** (every push-event run correctly skips it). A test-only diff would short-circuit the changed-line gate green (`tests/` is not a mutation pool); the docstring amendment to `scripts/slice_closeout_advisories.py` puts one eligible pool file in the PR range so the gate runs its full real path — coverage probe + changed-line classification. Decision recorded in the operating goal artifact (slice 3 of `charness-artifacts/goals/2026-06-10-postpush-verification-deleted-checkout-scan-pr-mirror.md`).

## Verification

- `tests/quality_gates/test_slice_closeout_new_pool_advisory.py` 8/8 green locally
- ruff + length headroom green; mirror `cmp` byte-identical
- Merges only when the PR-mirror job's verdict is green (run id + conclusion recorded in the goal artifact)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 풀 모듈 어드바이저 기능에 대한 설명서를 확장하여 실제 환경에서의 동작 방식을 명확히 했습니다.

* **Tests**
  * 풀 모듈 어드바이저가 실제 저장소 환경에서 올바르게 작동하는지 검증하는 엔드-투-엔드 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->